### PR TITLE
defines badgeClass in JSON-schema, sample extension, & sample badgeClass

### DIFF
--- a/badgeExtensions-schema/badgeClass.json
+++ b/badgeExtensions-schema/badgeClass.json
@@ -5,9 +5,9 @@
   "criteria": "https://example.org/extended-badge.html",
   "tags": ["badgeClassExtensions"],
   "issuer": "https://example.org/organization.json",
-  "badgeClassExtensions": [
+  "extensions": [
     {
-      "badgeSpecification": {
+      "schema": {
       	"title": "Badge Age Target",
         "reference": "http://this-domain.org/schema-age-target-v0.5.json",
         "version": "0.5"

--- a/badgeExtensions-schema/schema-age-target-v0.5.json
+++ b/badgeExtensions-schema/schema-age-target-v0.5.json
@@ -1,16 +1,16 @@
 {
-	"$schema": "http://json-schema.org/draft-04/schema#",
-	"title" : "Badge Age Target",
-	"description": "A suggested age or US grade range targeted by the described badge or learning experience. Use one or both options.",
-	"type": "object",
-	"properties": {
-		"age": {
-			"description": "The targeted age range for a badge or learning experience (e.g. '6-10')",
-			"type": "string"
-		},
-		"grade": {
-			"description": "The targeted US grade range for a badge or learning experience (e.g. 'K-3')",
-			"type": "string"
-		}
-	}
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title" : "Badge Age Target",
+  "description": "A suggested age or US grade range targeted by the described badge or learning experience. Use one or both options.",
+  "type": "object",
+  "properties": {
+    "age": {
+      "description": "The targeted age range for a badge or learning experience (e.g. '6-10')",
+      "type": "string"
+    },
+    "grade": {
+      "description": "The targeted US grade range for a badge or learning experience (e.g. 'K-3')",
+      "type": "string"
+    }
+  }
 }

--- a/badgeExtensions-schema/schema-badgeClass.json
+++ b/badgeExtensions-schema/schema-badgeClass.json
@@ -1,88 +1,88 @@
 {
-	"$schema": "http://json-schema.org/draft-04/schema#",
-	"title" : "Open Badge BadgeClass Definition v1.1",
-	"description": "A schematic defining how an issuer defines an open badge to issue to its users",
-	"type": "object",
-	"properties": {
-		"name": {
-			"description": "A name or title of the particular badge defined in the present badge class, which could then be issued to many recipients.",
-			"type": "string"
-		},
-		"description": {
-			"description": "A short description of the achievement represented by the present badge.",
-			"type": "string"
-		},
-		"image": {
-			"description": "The URL of the image that represents the present achievement. It will be baked into a complete badge for each recipient.",
-			"type": "string"
-		},
-		"criteria": {
-			"description": "The URL of a human-readable page describing the URL of the criteria for earning the achievement. If the badge represents an educational achievement, consider marking up this up with LRMI.",
-			"type": "string"
-		},
-		"issuer": {
-			"description": "URL of an object describing the organization that issued the badge. Endpoint should be JSON following the IssuerOrganization schema",
-			"type": "string"
-		},
-		"tags": {
-			"description": "An array of text: List of tags that describe the type of achievement.",
-			"type": "array",
-			"items": {
-				"type": "string"
-			}
-		},
-		"alignment": {
-			"description": "List of objects describing which educational standards this badge aligns to, if any. An array of AlignmentObjects.",
-			"type": "array",
-			"items": {
-				"type": "object",
-				"properties": {
-					"name": {
-						"description": "Name of the alignment.",
-						"type": "string"
-					},
-					"url": {
-						"description": "URL linking to the official description of the standard.",
-						"type": "string"
-					},
-					"description": {
-						"description": "Short description of the standard.",
-						"type": "string"
-					}
-				},
-				"required": ["name","url"]
-			}
-		},
-		"badgeClassExtensions": {
-			"description": "An array of objects each linking to and fulfilling a schema for additional badge class information",
-			"type": "array",
-			"items": {
-				"type": "object",
-				"properties": {
-					"badgeSpecification": {
-						"type": "object",
-						"properties": {
-							"title": {
-								"description": "Short descriptive name of the extension that indicates what information it will add to the badgeClass.",
-								"type": "string"
-							},
-							"reference": {
-								"description": "URL to the JSON-schema file defining the structure of this extension",
-								"type": "string"
-							},
-							"version": {
-								"description": "Version string of the extension (is this necessary or should it be folded into the reference?)",
-								"type": "string"
-							}
-						},
-						"required": ["reference"]
-					},
-					"content": {
-						"type": "object"
-					}
-				},
-				"required": ["badgeSpecification", "content"]
-			}
-		}
-	}
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title" : "Open Badge BadgeClass Definition v1.1",
+  "description": "A schematic defining how an issuer defines an open badge to issue to its users",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "A name or title of the particular badge defined in the present badge class, which could then be issued to many recipients.",
+      "type": "string"
+    },
+    "description": {
+      "description": "A short description of the achievement represented by the present badge.",
+      "type": "string"
+    },
+    "image": {
+      "description": "The URL of the image that represents the present achievement. It will be baked into a complete badge for each recipient.",
+      "type": "string"
+    },
+    "criteria": {
+      "description": "The URL of a human-readable page describing the criteria for earning the achievement. If the badge represents an educational achievement, consider marking up this up with LRMI.",
+      "type": "string"
+    },
+    "issuer": {
+      "description": "URL of an object describing the organization that issued the badge. Endpoint should be JSON following the IssuerOrganization schema",
+      "type": "string"
+    },
+    "tags": {
+      "description": "An array of text: List of tags that describe the type of achievement.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "alignment": {
+      "description": "List of objects describing which educational standards this badge aligns to, if any. An array of AlignmentObjects.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Name of the alignment.",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL linking to the official description of the standard.",
+            "type": "string"
+          },
+          "description": {
+            "description": "Short description of the standard.",
+            "type": "string"
+          }
+        },
+        "required": ["name","url"]
+      }
+    },
+    "extensions": {
+      "description": "An array of objects each linking to and fulfilling a schema for additional badge class information",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "schema": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "description": "Short descriptive name of the extension that indicates what information it will add to the badgeClass.",
+                "type": "string"
+              },
+              "reference": {
+                "description": "URL to the JSON-schema file defining the structure of this extension",
+                "type": "string"
+              },
+              "version": {
+                "description": "Version string of the extension (is this necessary or should it be folded into the reference?)",
+                "type": "string"
+              }
+            },
+            "required": ["reference"]
+          },
+          "content": {
+            "type": "object"
+          }
+        },
+        "required": ["schema", "content"]
+      }
+    }
+  }
 }


### PR DESCRIPTION
I started with a sample badgeClass, including a simple badgeClassExtension that allows issuers to define an age target in years or US standard grades (as human readable strings like "6-12" or "P-20").

Initially I used @kayaelle's example from mozilla/openbadges-discussion/issues/8 but I made a couple small changes that I think might help the extensions work better with JSON-schema. 

I made each extension, as included in the badgeClass, be an object with two properties ("badgeSpecification" and "content") rather than just a "badgeSpecification" object followed by more properties that vary depending on the extension. I think for validation, we will want to compare the "content" object to the schema at the reference URL defined in badgeSpecification["reference"].

Please correct any errors you might find, and investigate any changes that would improve things.

Hopefully ya'll don't mind my folder structure. I put these in a folder for JSON-schema based exploration, thinking others could create separate folders for JSON-LD and current-spec style namespaced properties.
